### PR TITLE
Fix: Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM docker.io/python                                        
-                                                             
+FROM python:3.11
 ENV UVICORN_HOST 0.0.0.0                                     
-ENV UVICORN_PORT 8080                                          
-                                                             
-RUN pip3 install minstrel[prod]                              
-                                                             
-EXPOSE 8080                                                    
-                                                             
-CMD [ -f ../var/minstrel-instance/minstrel.sqlite ] || quart --app minstrel init-db ; uvicorn --factory minstrel:create_app
+ENV UVICORN_PORT 8080
+WORKDIR /app
+COPY . /app
+RUN pip3 install .[prod]
+EXPOSE 8080
+CMD [ -f /app/instance/minstrel.sqlite ] || quart --app minstrel init-db ; uvicorn --factory minstrel:create_app


### PR DESCRIPTION
### Description

This patch closes #2. During docker build, application files should be copied to the working directory. Additionally, the Python version is fixed to `3.11`.  

#### Verification Steps

```shell
buildah bud -t minstrel .
podman run -dt -p 8080:8080 -v $HOME:/app/instance --name minstrel minstrel

```

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
