### PR TITLE
Fix: Overlapping Scroll Button 

### DIFF
--- a/minstrel/static/site.css
+++ b/minstrel/static/site.css
@@ -68,7 +68,7 @@ header {
     top: 0;
 }
 
-main {padding: 6.5rem 1rem 1rem}
+main {padding: 6.5rem 1rem 5rem}
 section {padding-bottom: 2rem}
 h1 {color: var(--color-title); font-size: 2rem; font-weight: 700}
 h2 {color: var(--color-title); font-size: 1.5rem; font-weight: 500}


### PR DESCRIPTION
### Description

This patch closes #3. Current Scroll-To-Top button overlaps with buttons at the bottom of pages. Adding padding to the bottom of the main tag prevents.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
